### PR TITLE
Adjust Timesweeper game over modal buttons

### DIFF
--- a/frontend/src/views/gallery/timesweeper/index.js
+++ b/frontend/src/views/gallery/timesweeper/index.js
@@ -233,15 +233,10 @@ export function render(){
     }
 
     // Actions
-    const actions = won
-      ? [
-          { label: 'New Game', onClick: () => { newGame(); } },
-          { label: 'Quit', variant: 'secondary', onClick: () => { try { sessionStorage.removeItem('ts:chosen'); } catch {} location.hash = '#/gallery/timesweeper'; } },
-        ]
-      : [
-          { label: 'Continue', onClick: () => {} },
-          { label: 'Quit', variant: 'secondary', onClick: () => { try { sessionStorage.removeItem('ts:chosen'); } catch {} location.hash = '#/gallery/timesweeper'; } },
-        ];
+    const actions = [
+      { label: 'New Game', onClick: () => { newGame(); } },
+      { label: 'View Board', variant: 'secondary', onClick: () => { try { endModalHandle?.close?.(); } catch {} } },
+    ];
 
     // Open global modal
     endModalHandle = openModal({


### PR DESCRIPTION
## Summary
- replace the Timesweeper Game Over modal actions with "New Game" and "View Board"
- wire "New Game" to start a fresh board and "View Board" to simply close the modal

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd6d95c6ec8327a494dc664579583c