### PR TITLE
Hide Timesweeper solve/best times on losses

### DIFF
--- a/frontend/src/views/gallery/timesweeper/index.js
+++ b/frontend/src/views/gallery/timesweeper/index.js
@@ -202,7 +202,10 @@ export function render(){
     const lossesEl = document.createElement('span'); lossesEl.id = 'ts-losses'; lossesEl.textContent = '0';
     const winpctEl = document.createElement('span'); winpctEl.id = 'ts-winpct'; winpctEl.textContent = '0%';
     pWL.append(document.createTextNode('Wins: '), winsEl, document.createTextNode(' \u00A0 Losses: '), lossesEl, document.createTextNode(' \u00A0 Win%: '), winpctEl);
-    statsBlock.append(pSolve, pBest, pWL);
+    if (won) {
+      statsBlock.append(pSolve, pBest);
+    }
+    statsBlock.append(pWL);
     const customNote = document.createElement('div');
     customNote.id = 'ts-custom-note';
     customNote.style.display = 'none';


### PR DESCRIPTION
## Summary
- only append the solve and best time rows to the Timesweeper modal when the player wins
- keep the win/loss record visible for all outcomes while hiding time stats on losses

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d14ce2a260832788eed7a927e7e9a3