### PR TITLE
Add post-loss new game button under Timesweeper board

### DIFF
--- a/frontend/src/views/gallery/timesweeper/index.js
+++ b/frontend/src/views/gallery/timesweeper/index.js
@@ -48,7 +48,17 @@ export function render(){
   boardHost.className='ts-board';
   boardHost.style.setProperty('--ts-cols', '30');
 
-  wrap.append(header, boardHost);
+  const postLossBar = document.createElement('div');
+  postLossBar.className = 'ts-post-loss';
+  postLossBar.style.display = 'none';
+  const postLossBtn = document.createElement('button');
+  postLossBtn.type = 'button';
+  postLossBtn.className = 'button';
+  postLossBtn.textContent = 'New Game';
+  postLossBtn.addEventListener('click', () => { newGame(); });
+  postLossBar.append(postLossBtn);
+
+  wrap.append(header, boardHost, postLossBar);
   frag.append(sub.root, wrap, srcPane);
 
   // Prevent native context menu anywhere in the Timesweeper area (immersion)
@@ -79,6 +89,14 @@ export function render(){
   const fuseEl = wrap.querySelector('#ts-fuse');
   // Modal element handles are built when opening the modal
   let endModalHandle = null;
+
+  function hidePostLossButton(){
+    postLossBar.style.display = 'none';
+  }
+
+  function showPostLossButton(){
+    postLossBar.style.display = 'flex';
+  }
 
   const fmt = (ms)=> formatTenths(ms||0);
 
@@ -248,6 +266,10 @@ export function render(){
       actions,
       titleAlign: 'center',
       actionsAlign: 'center',
+      onClose: () => {
+        if (!won && gameOver) { showPostLossButton(); }
+        else { hidePostLossButton(); }
+      },
     });
   }
 
@@ -263,6 +285,7 @@ export function render(){
     setFuseDisplay(fuseRemainingMs, false);
     // ensure initial grid size is set
     boardHost.style.setProperty('--ts-cols', String(W));
+    hidePostLossButton();
     paint();
   }
 

--- a/frontend/styling/components.css
+++ b/frontend/styling/components.css
@@ -323,6 +323,8 @@
 .ts-controls #ts-new.button:hover { filter: brightness(1.05); }
 
 .ts-board { --ts-size: 28px; --ts-gap: 0px; display: grid; grid-template-columns: repeat(var(--ts-cols), var(--ts-size)); gap: var(--ts-gap); justify-content: center; margin-top: var(--space-4); }
+.ts-post-loss { margin-top: var(--space-5); display: flex; justify-content: center; }
+.ts-post-loss .button { min-width: 140px; }
 .ts-cell { width: var(--ts-size); height: var(--ts-size); border-radius: 4px; border: 1px solid var(--border); background: var(--bg-elev); color: var(--text); display: grid; place-items: center; font-weight: 700; cursor: pointer; user-select: none; }
 .ts-cell.hidden { background: var(--bg-elev); }
 .ts-cell.hidden.flagged { background: #1a2233; position: relative; }


### PR DESCRIPTION
## Summary
- add a persistent "New Game" button under the Timesweeper board that reuses the existing reset logic
- surface the button only after a loss when the modal is closed so players can restart while studying the revealed board
- style the new button row to sit centered beneath the board

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d152b95c948327ae5540103e9085bd