### PR TITLE
Show post-game button after closing win modal

### DIFF
--- a/frontend/src/views/gallery/timesweeper/index.js
+++ b/frontend/src/views/gallery/timesweeper/index.js
@@ -267,7 +267,7 @@ export function render(){
       titleAlign: 'center',
       actionsAlign: 'center',
       onClose: () => {
-        if (!won && gameOver) { showPostLossButton(); }
+        if (gameOver) { showPostLossButton(); }
         else { hidePostLossButton(); }
       },
     });


### PR DESCRIPTION
## Summary
- show the in-board New Game button after closing the post-game modal regardless of win or loss

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d157058ea08327b1ef52439efb1d96