### PR TITLE
Highlight time bomb tile after losses

### DIFF
--- a/frontend/src/views/gallery/timesweeper/index.js
+++ b/frontend/src/views/gallery/timesweeper/index.js
@@ -132,6 +132,7 @@ export function render(){
         cls += c.hidden ? ' hidden' : ' revealed';
         if (c.hidden && c.flagged) cls += c.isTimebomb ? ' tflag' : ' flagged';
         if (!c.hidden && c.isMine) cls += ' mine';
+        if (!c.hidden && c.isTimebomb) cls += ' timebomb';
         if (!c.hidden && !c.isMine && c.neighbors>0) cls += ' n' + c.neighbors;
         b.className = cls;
         b.dataset.x = String(x); b.dataset.y = String(y);

--- a/frontend/styling/components.css
+++ b/frontend/styling/components.css
@@ -333,6 +333,10 @@
 .ts-cell.hidden.tflag::after { content: '\2691'; color: #10b981; font-size: 16px; }
 .ts-cell.revealed { background: #f3f4f6; color: #111827; }
 .ts-cell.revealed.mine { background: #ffffff; color: #111; border-color: #ef4444; position: relative; }
+.ts-cell.revealed.mine.timebomb {
+  background: #d1fae5;
+  border-color: #10b981;
+}
 /* Use a bomb/sea‑mine icon; center perfectly */
 .ts-cell.revealed.mine::after {
   content: '💣';


### PR DESCRIPTION
## Summary
- mark revealed time bomb tiles with a dedicated CSS class during board rendering
- style the revealed time bomb with a green background and border to set it apart from other mines

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d59c12338c83279907c04abe2b55cb