### PR TITLE
Arrange Pips Solver palette into two rows

### DIFF
--- a/frontend/src/views/gallery/pipsSolver/src/board.js
+++ b/frontend/src/views/gallery/pipsSolver/src/board.js
@@ -247,6 +247,7 @@ export default class Board {
       .pips-cell.in-puzzle  { background: tan; border: 1px solid #996; }
       .pips-cell.in-puzzle.in-area {
         background: tan;
+        background: color-mix(in srgb, var(--area-color, #996) 22%, tan 78%);
         border-color: var(--area-color, #996);
         box-shadow: 0 0 0 2px color-mix(in srgb, var(--area-color, #996) 45%, #ffffff 55%);
       }

--- a/frontend/src/views/gallery/pipsSolver/src/constants.js
+++ b/frontend/src/views/gallery/pipsSolver/src/constants.js
@@ -5,13 +5,11 @@ export const Modes = {
 };
 
 export const PALETTE = [
-  "#ff1744", // neon red
-  "#ff9100", // orange
-  "#ffd600", // yellow
-  "#76ff03", // light green
-  "#00c853", // dark green
-  "#40c4ff", // light blue
-  "#2979ff", // dark blue
-  "#d500f9", // purple
+  "#EB004F",
+  "#C94E00",
+  "#4C6C01",
+  "#006571",
+  "#003674",
+  "#8047B0",
 ];
 

--- a/frontend/src/views/gallery/pipsSolver/src/utils/ui.js
+++ b/frontend/src/views/gallery/pipsSolver/src/utils/ui.js
@@ -58,7 +58,7 @@ export function ensureBaseStyles() {
 
     hr { border: none; border-top: 1px solid #eee; margin: 6px 0; }
 
-    .palette { display: grid; grid-template-columns: repeat(4, 1fr); gap: 8px; }
+    .palette { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 8px; }
     .color { width: 100%; aspect-ratio: 2/1; border-radius: 6px; border: 2px solid rgba(0,0,0,0.25); cursor: pointer; background: #fff; }
     .color.is-selected { outline: 2px solid #000; outline-offset: 2px; }
 


### PR DESCRIPTION
## Summary
- replace the Define Areas palette with the requested six custom hex colors
- tint painted board cells with the selected area color so the updated palette is reflected on the grid
- lay out the Define Areas palette swatches in two rows of three buttons

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6a2f33e348327863ddc5977d58640