### PR TITLE
Adjust pips solver palette layout

### DIFF
--- a/frontend/src/views/gallery/pipsSolver/src/utils/ui.js
+++ b/frontend/src/views/gallery/pipsSolver/src/utils/ui.js
@@ -58,7 +58,11 @@ export function ensureBaseStyles() {
 
     hr { border: none; border-top: 1px solid #eee; margin: 6px 0; }
 
-    .palette { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 8px; }
+    .pips-sidebar .palette {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 8px;
+    }
     .color { width: 100%; aspect-ratio: 2/1; border-radius: 6px; border: 2px solid rgba(0,0,0,0.25); cursor: pointer; background: #fff; }
     .color.is-selected { outline: 2px solid #000; outline-offset: 2px; }
 


### PR DESCRIPTION
## Summary
- scope the pips solver color palette styling to the sidebar panel
- enforce a three-column grid so the six swatches render as two rows of three

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d6ac1bd7c88327bdea872e07802339