### PR TITLE
Adjust Predict Four modal winner logic

### DIFF
--- a/frontend/src/views/gallery/predictfour/game.js
+++ b/frontend/src/views/gallery/predictfour/game.js
@@ -979,6 +979,11 @@ function finishGame(state, winnerIdx, status, hud) {
     };
   });
 
+  let pointsWinner = null;
+  const highestTotal = Math.max(...totals.map(entry => entry.total));
+  const leaders = totals.filter(entry => entry.total === highestTotal);
+  if (leaders.length === 1) pointsWinner = leaders[0];
+
   hud.panels.forEach((panel, idx) => {
     if (panel.pointsStat) {
       panel.pointsStat.val.textContent = String(totals[idx].total);
@@ -1010,18 +1015,26 @@ function finishGame(state, winnerIdx, status, hud) {
     },
   ];
 
+  const modalTitle = pointsWinner
+    ? `${pointsWinner.name} wins on points!`
+    : winner
+      ? `${winner.name} wins!`
+      : 'Game over';
+
   openModal({
-    title: winner ? `${winner.name} wins!` : 'Game over',
-    body: buildSummaryBody(totals, winnerIdx, state),
+    title: modalTitle,
+    body: buildSummaryBody(totals, winnerIdx, state, pointsWinner),
     actions: modalActions,
   });
 }
 
-function buildSummaryBody(totals, winnerIdx, state) {
+function buildSummaryBody(totals, winnerIdx, state, pointsWinner) {
   const wrap = document.createElement('div');
   wrap.className = 'stack';
   const intro = document.createElement('p');
-  if (typeof winnerIdx === 'number') {
+  if (pointsWinner) {
+    intro.textContent = `${pointsWinner.name} takes the match on total points.`;
+  } else if (typeof winnerIdx === 'number') {
     intro.textContent = 'Final scores';
     intro.style.fontWeight = '700';
   } else {


### PR DESCRIPTION
## Summary
- determine the points leader when finishing a Predict Four match
- update the game over modal title and intro copy to credit the points winner
- keep existing board win messaging as a fallback when totals are tied

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc029610d483278f9e5ccf9c5e1367